### PR TITLE
.gitkeep files in data/runtime subdirectories should be kept in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ Icon
 # Runtime Files
 # ---------------
 
-/data/runtime/*
+/data/runtime/*/*
 !/data/runtime/cache/.gitkeep
 !/data/runtime/logs/.gitkeep
 !/data/runtime/sessions/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,8 @@ Icon
 # Runtime Files
 # ---------------
 
-/data/runtime/*/*
-!/data/runtime/cache/.gitkeep
-!/data/runtime/logs/.gitkeep
-!/data/runtime/sessions/.gitkeep
+/data/runtime/**
+!/data/runtime/**/.gitkeep
 
 # License
 # ---------------


### PR DESCRIPTION
For me, the `.gitignore` configuration still made it so that the `.gitkeep`s in `data/runtime` subdirectories are ignored. The small adjustment made the exclusion rules work for me.


