### PR TITLE
Fix license path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ Icon
 # License
 # ---------------
 
-/data/storage/.license
+/site/config/.license


### PR DESCRIPTION
## Description
This PR fixes the license path to be ignored in .gitignore

### Reasoning
I'm not sure if this is intended with this setup but the licence path should be `/site/config/.license` by default